### PR TITLE
Add Headers To Fetch and Expose simpleFetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,22 @@ import { simple } from "simple-fetch-ts";
 
 ---
 
+## SimpleTsFetch
+
+If you want an inflexible, but quick way to make a simple fetch request, you can use simpleTsFetch. simpleFetch skips the response object and returns your parsed
+data directly. It uses the same fetch helper as the factory function, handling errors internally.
+
+```typescript
+import { simpleTsFetch } from "simple-fetch-ts";
+
+const response = await simpleTsFetch<MyResponseType[]>(
+  "https://api.example.com/resource",
+);
+console.log(response);
+```
+
+---
+
 ## API Reference
 
 ### `simple(url: string): FetchWrapper`
@@ -170,7 +186,9 @@ interface FetchTsResponse<T> {
 
 ---
 
-## Example
+## Examples
+
+### Step By Step
 
 ```typescript
 import { simple } from "simple-fetch-ts";
@@ -192,11 +210,85 @@ console.log("Status:", response.status);
 console.log("Headers:", response.headers);
 ```
 
+### Simple Post
+
+```typeScript
+const result = await simple("https://api.example.com/resource").body({ name: "example", location: "example" }).post<ExpectedReturnType>();
+return result.data;
+```
+
+### Equivelant Code Using Native Fetch
+
+```typescript
+const url = "https://api.example.com/resource";
+try {
+  const response = await fetch(url, {
+    method: "POST",
+    body: JSON.stringify({ name: "example", location: "example" }),
+    headers: { "Content-Type": "application/json" },
+  });
+  if (!response.ok) {
+    return {
+      error: `Network response status ${response.status} with url ${url}`,
+    };
+  }
+  const parsedResponse: ExpectedReturnType = await response.json();
+  return parsedResponse;
+} catch (error: unknown) {
+  throw new Error(
+    error instanceof Error ? error.message : "An unknown error occurred",
+  );
+}
+```
+
 ---
 
 ## Error Handling
 
 The library ensures consistent error messages for invalid configurations or failed requests. Errors are thrown as `Error` objects with detailed messages.
+
+---
+
+## tsFetch Function
+
+Both `simpleTsFetch()` and `simple.fetch()` use `tsFetch()`:
+
+```typescript
+/**
+ * Performs a typed fetch request to the specified URL.
+ * @param url - The URL to fetch data from.
+ * @returns A promise that resolves with the fetched data, status, and headers.
+ * @throws Will throw an error if the fetch fails or the response is not OK.
+ */
+export const tsFetch = async <T>(
+  url: string,
+  requestHeaders: HeadersInit = {},
+): Promise<FetchTsResponse<T>> => {
+  try {
+    const response = await fetch(url, {
+      method: "GET",
+      headers: { ...requestHeaders },
+    });
+
+    if (!response.ok) {
+      throw new Error(
+        `Network response status ${response.status} with URL: ${url}`,
+      );
+    }
+
+    const data: T = await response.json();
+    return {
+      data,
+      status: response.status,
+      headers: response.headers,
+    };
+  } catch (error: unknown) {
+    throw new Error(
+      error instanceof Error ? error.message : "An unknown error occurred",
+    );
+  }
+};
+```
 
 ---
 

--- a/src/__tests__/fetch/index.test.ts
+++ b/src/__tests__/fetch/index.test.ts
@@ -26,7 +26,10 @@ describe("typedFetch", () => {
       status: 200,
       headers: mockResponse.headers,
     });
-    expect(fetch).toHaveBeenCalledWith("/test-url");
+    expect(fetch).toHaveBeenCalledWith("/test-url", {
+      headers: {},
+      method: "GET",
+    });
   });
 
   it("should throw an error for non-200 responses", async () => {

--- a/src/__tests__/simple-fetch-ts/index.test.ts
+++ b/src/__tests__/simple-fetch-ts/index.test.ts
@@ -12,10 +12,14 @@ describe("simpleTsFetch", () => {
     const mockData = { id: 1, name: "Test" };
     (tsFetch as jest.Mock).mockResolvedValueOnce({ data: mockData });
 
-    const result = await simpleTsFetch("/test-url");
+    const result = await simpleTsFetch("/test-url", {
+      Authorization: "Bearer Token",
+    });
 
     expect(result).toEqual(mockData);
-    expect(tsFetch).toHaveBeenCalledWith("/test-url");
+    expect(tsFetch).toHaveBeenCalledWith("/test-url", {
+      Authorization: "Bearer Token",
+    });
   });
 
   it("should throw an error when typedFetch fails", async () => {

--- a/src/__tests__/simple-fetch-ts/index.test.ts
+++ b/src/__tests__/simple-fetch-ts/index.test.ts
@@ -1,4 +1,4 @@
-import { simpleTsFetch } from "../../simple-fetch-ts";
+import { simpleFetch } from "../../simple-fetch-ts";
 import { tsFetch } from "../../fetch";
 
 jest.mock("../../fetch"); // Mock the entire module
@@ -12,7 +12,7 @@ describe("simpleTsFetch", () => {
     const mockData = { id: 1, name: "Test" };
     (tsFetch as jest.Mock).mockResolvedValueOnce({ data: mockData });
 
-    const result = await simpleTsFetch("/test-url", {
+    const result = await simpleFetch("/test-url", {
       Authorization: "Bearer Token",
     });
 
@@ -26,14 +26,14 @@ describe("simpleTsFetch", () => {
     const errorMessage = "Network error";
     (tsFetch as jest.Mock).mockRejectedValueOnce(new Error(errorMessage));
 
-    await expect(simpleTsFetch("/test-url")).rejects.toThrow(errorMessage);
+    await expect(simpleFetch("/test-url")).rejects.toThrow(errorMessage);
   });
 
   it("should throw an error when typedFetch returns an unexpected result", async () => {
     (tsFetch as jest.Mock).mockResolvedValueOnce({ data: undefined });
 
     // We expect an error to be thrown since the fetch response contains no data
-    await expect(simpleTsFetch("/test-url")).rejects.toThrow(
+    await expect(simpleFetch("/test-url")).rejects.toThrow(
       "No data returned from the fetch for URL: /test-url",
     );
   });

--- a/src/__tests__/wrapper/index.test.ts
+++ b/src/__tests__/wrapper/index.test.ts
@@ -128,7 +128,7 @@ describe("FetchWrapper", () => {
 
     it("should call the correct request function for GET", async () => {
       const response = await fetchWrapper.params(mockParams).fetch();
-      expect(tsFetch).toHaveBeenCalledWith(`${mockUrl}?page=1&limit=10`);
+      expect(tsFetch).toHaveBeenCalledWith(`${mockUrl}?page=1&limit=10`, {});
       expect(response).toEqual(mockResponse);
     });
 

--- a/src/fetch/index.ts
+++ b/src/fetch/index.ts
@@ -3,12 +3,19 @@ import { FetchTsResponse } from "../types";
 /**
  * Performs a typed fetch request to the specified URL.
  * @param url - The URL to fetch data from.
+ * @param requestHeaders - Optional headers to be sent with the request.
  * @returns A promise that resolves with the fetched data, status, and headers.
  * @throws Will throw an error if the fetch fails or the response is not OK.
  */
-export const tsFetch = async <T>(url: string): Promise<FetchTsResponse<T>> => {
+export const tsFetch = async <T>(
+  url: string,
+  requestHeaders: HeadersInit = {},
+): Promise<FetchTsResponse<T>> => {
   try {
-    const response = await fetch(url);
+    const response = await fetch(url, {
+      method: "GET",
+      headers: { ...requestHeaders },
+    });
 
     if (!response.ok) {
       throw new Error(

--- a/src/post/index.ts
+++ b/src/post/index.ts
@@ -3,8 +3,8 @@ import { FetchTsResponse } from "../types";
 /**
  * Performs a typed post request to the specified URL.
  * @param url - The URL to fetch data from.
- * @param requestBody - data to be sent as the request body
- * @param requestHeaders - headers to be sent with the request
+ * @param requestBody - The data to be sent as the request body.
+ * @param requestHeaders - Optional headers to be sent with the request.
  * @returns A promise that resolves with the fetched data, status, and headers.
  * @throws Will throw an error if the fetch fails or the response is not OK.
  */

--- a/src/simple-fetch-ts/index.ts
+++ b/src/simple-fetch-ts/index.ts
@@ -7,7 +7,7 @@ import { tsFetch } from "../fetch";
  * @returns The data returned from the fetch.
  * @throws Will throw an error if the fetch fails or the response is not OK.
  */
-export const simpleTsFetch = async <T>(
+export const simpleFetch = async <T>(
   url: string,
   requestHeaders: HeadersInit = {},
 ): Promise<T> => {

--- a/src/simple-fetch-ts/index.ts
+++ b/src/simple-fetch-ts/index.ts
@@ -3,11 +3,15 @@ import { tsFetch } from "../fetch";
 /**
  * Fetches data from the given URL and returns the data part of the response.
  * @param url - The URL to fetch data from.
+ * @param requestHeaders - Optional headers to be sent with the request.
  * @returns The data returned from the fetch.
  * @throws Will throw an error if the fetch fails or the response is not OK.
  */
-export const simpleTsFetch = async <T>(url: string): Promise<T> => {
-  const result = await tsFetch<T>(url);
+export const simpleTsFetch = async <T>(
+  url: string,
+  requestHeaders: HeadersInit = {},
+): Promise<T> => {
+  const result = await tsFetch<T>(url, requestHeaders);
   if (!result?.data) {
     throw new Error(`No data returned from the fetch for URL: ${url}`);
   }

--- a/src/wrapper/index.ts
+++ b/src/wrapper/index.ts
@@ -103,7 +103,10 @@ export class FetchWrapper {
 
   async fetch<T>(): Promise<FetchTsResponse<T>> {
     const fullUrl = this.buildUrl();
-    return this.handleRequest(() => tsFetch<T>(fullUrl), "GET");
+    return this.handleRequest(
+      () => tsFetch<T>(fullUrl, this.requestHeaders),
+      "GET",
+    );
   }
 
   async post<T>(): Promise<FetchTsResponse<T>> {


### PR DESCRIPTION
- Add header options to simple.fetch() and simpleFetch()
- Renamed simpleTsFetch to simpleFetch() and added to documentation
- Updated tests