### PR TITLE
Return raw response

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ import { simpleFetch } from "simple-fetch-ts";
  * @throws Will throw an error if the fetch fails or the response is not OK.
  */
 const response = await simpleFetch<ExpectedReturnType[]>(
-  "https://api.example.com/resource"
+  "https://api.example.com/resource",
 );
 if (data === null) {
   console.log("No data found, handling gracefully.");
@@ -259,7 +259,7 @@ try {
   return parsedResponse;
 } catch (error: unknown) {
   throw new Error(
-    error instanceof Error ? error.message : "An unknown error occurred"
+    error instanceof Error ? error.message : "An unknown error occurred",
   );
 }
 ```
@@ -307,12 +307,12 @@ export class SimpleFetchRequestError extends Error {
     public url: string,
     public status?: number,
     public statusText?: string,
-    public responseBody?: any
+    public responseBody?: any,
   ) {
     super(
       `${method} request to ${url} failed with status ${status ?? "unknown"}: ${
         statusText ?? "No status text"
-      }`
+      }`,
     );
     this.name = "SimpleFetchRequestError";
   }
@@ -334,7 +334,7 @@ export class InvalidURLError extends Error {
    */
   constructor(url: string) {
     super(
-      `A valid URL is required, received: ${url}. Ensure the URL starts with "http://" or "https://".`
+      `A valid URL is required, received: ${url}. Ensure the URL starts with "http://" or "https://".`,
     );
     this.name = "InvalidURLError";
   }
@@ -376,7 +376,7 @@ import { SimpleResponse } from "../../types";
  */
 export const tsFetch = async <T>(
   url: string,
-  requestHeaders: HeadersInit = {}
+  requestHeaders: HeadersInit = {},
 ): Promise<SimpleResponse<T>> => {
   try {
     const response = await fetch(url, {
@@ -393,7 +393,7 @@ export const tsFetch = async <T>(
         url,
         response.status,
         response.statusText,
-        errorText
+        errorText,
       );
     }
 
@@ -408,7 +408,7 @@ export const tsFetch = async <T>(
       throw error; // Rethrow for consistent handling upstream
     }
     throw new Error(
-      error instanceof Error ? error.message : "An unknown error occurred"
+      error instanceof Error ? error.message : "An unknown error occurred",
     );
   }
 };
@@ -438,8 +438,8 @@ As part of maintaining high-quality standards, **`simple-fetch-ts`** ensures rob
 
 ## Test Coverage Report
 
-| **File**                 | **% Stmts** | **% Branch** | **% Funcs** | **% Lines** | **Uncovered Line #s** |
-|--------------------------|-------------|--------------|-------------|-------------|-----------------------|
+| **File**                  | **% Stmts** | **% Branch** | **% Funcs** | **% Lines** | **Uncovered Line #s** |
+| ------------------------- | ----------- | ------------ | ----------- | ----------- | --------------------- |
 | **All files**             | 96.41%      | 83.16%       | 88.37%      | 96.19%      |                       |
 | **builder**               | 100%        | 100%         | 100%        | 100%        |                       |
 | **errors**                | 100%        | 83.33%       | 100%        | 100%        |                       |
@@ -457,7 +457,6 @@ As part of maintaining high-quality standards, **`simple-fetch-ts`** ensures rob
 | **utility**               | 94.59%      | 93.75%       | 100%        | 93.93%      |                       |
 | - get-content-type.ts     | 90.9%       | 100%         | 100%        | 90%         | Line 26               |
 | - url-helpers.ts          | 96.15%      | 89.47%       | 100%        | 95.65%      | Line 58               |
-
 
 #### Observations
 

--- a/src/builder/index.ts
+++ b/src/builder/index.ts
@@ -116,7 +116,7 @@ export class SimpleBuilder {
     try {
       return await requestFn();
     } catch (error) {
-      console.error(`Error with ${method} request to ${this.url}:`, error);
+      console.error(`Error with ${method} request to ${this.url}:`, error); // @TODO allow logger configuration
       throw error;
     }
   }

--- a/src/methods/delete/index.ts
+++ b/src/methods/delete/index.ts
@@ -38,6 +38,7 @@ export const tsDelete = async <T>(
       data,
       status: response.status,
       headers: response.headers,
+      raw: response,
     };
   } catch (error: unknown) {
     if (error instanceof SimpleFetchRequestError) {

--- a/src/methods/delete/index.ts
+++ b/src/methods/delete/index.ts
@@ -7,7 +7,7 @@ import { SimpleResponse } from "../../types";
  * @template T - The type of the expected response data.
  * @param url - The URL to send the request to.
  * @param requestHeaders - Optional headers to be sent with the request.
- * @returns A promise that resolves with the response status and headers.
+ * @returns A promise that resolves with a SimpleResponse object.
  * @throws Will throw an error if the fetch fails or the response is not OK.
  */
 export const tsDelete = async <T>(

--- a/src/methods/fetch/index.ts
+++ b/src/methods/fetch/index.ts
@@ -38,6 +38,7 @@ export const tsFetch = async <T>(
       data,
       status: response.status,
       headers: response.headers,
+      raw: response,
     };
   } catch (error: unknown) {
     if (error instanceof SimpleFetchRequestError) {

--- a/src/methods/fetch/index.ts
+++ b/src/methods/fetch/index.ts
@@ -7,7 +7,7 @@ import { SimpleResponse } from "../../types";
  * @template T - The type of the expected response data.
  * @param url - The URL to fetch data from.
  * @param requestHeaders - Optional headers to be sent with the request.
- * @returns A promise that resolves with the fetched data, status, and headers.
+ * @returns A promise that resolves with a SimpleResponse object.
  * @throws Will throw an error if the fetch fails or the response is not OK.
  */
 export const tsFetch = async <T>(

--- a/src/methods/patch/index.ts
+++ b/src/methods/patch/index.ts
@@ -55,6 +55,7 @@ export const tsPatch = async <T>(
       data,
       status: response.status,
       headers: response.headers,
+      raw: response,
     };
   } catch (error: unknown) {
     if (error instanceof SimpleFetchRequestError) {

--- a/src/methods/patch/index.ts
+++ b/src/methods/patch/index.ts
@@ -12,7 +12,7 @@ import { getContentType } from "../../utility/get-content-type";
  * @param url - The URL to send the request to.
  * @param requestBody - The data to be sent as the request body.
  * @param requestHeaders - Optional headers to be sent with the request.
- * @returns A promise that resolves with the response data, status, and headers.
+ * @returns A promise that resolves with a SimpleResponse object.
  * @throws Will throw an error if the fetch fails or the response is not OK.
  */
 export const tsPatch = async <T>(

--- a/src/methods/post/index.ts
+++ b/src/methods/post/index.ts
@@ -57,6 +57,7 @@ export const tsPost = async <T>(
       data,
       status: response.status,
       headers: response.headers,
+      raw: response,
     };
   } catch (error: unknown) {
     if (error instanceof SimpleFetchRequestError) {

--- a/src/methods/post/index.ts
+++ b/src/methods/post/index.ts
@@ -12,7 +12,7 @@ import { getContentType } from "../../utility/get-content-type";
  * @param url - The URL to send the request to.
  * @param requestBody - The data to be sent as the request body.
  * @param requestHeaders - Optional headers to include with the request.
- * @returns A promise that resolves with the response data, status, and headers.
+ * @returns A promise that resolves with a SimpleResponse object.
  * @throws Will throw an error if the fetch fails or the response status is not OK.
  */
 export const tsPost = async <T>(

--- a/src/methods/put/index.ts
+++ b/src/methods/put/index.ts
@@ -52,6 +52,7 @@ export const tsPut = async <T>(
       data,
       status: response.status,
       headers: response.headers,
+      raw: response,
     };
   } catch (error: unknown) {
     if (error instanceof SimpleFetchRequestError) {

--- a/src/methods/put/index.ts
+++ b/src/methods/put/index.ts
@@ -9,7 +9,7 @@ import { getContentType } from "../../utility/get-content-type";
  * @param url - The URL to send the request to.
  * @param requestBody - The data to be sent as the request body.
  * @param requestHeaders - Optional headers to be sent with the request.
- * @returns A promise that resolves with the response data, status, and headers.
+ * @returns A promise that resolves with a SimpleResponse object.
  * @throws Will throw an error if the fetch fails or the response is not OK.
  */
 export const tsPut = async <T>(

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,6 +2,7 @@ export interface SimpleResponse<T> {
   data: T;
   status: number;
   headers: Headers;
+  raw: Response;
 }
 
 export type QueryParams = Record<string, string | number | (string | number)[]>;


### PR DESCRIPTION
## Description of Change
- Return the raw Response object as a property on SimpleResponse
- This will give the user a lot more flexibility with how to handle responses
- If a user doesn't need it, they don't need to access it
- naming it raw: Response, to avoid needing to do something like `response.response`, since `response.raw` is more semantic
- Needs test coverage